### PR TITLE
support for detecting collection by template_id (#72) + fix for delete and download processes

### DIFF
--- a/datapackage_pipelines_mojp/clearmash/common.py
+++ b/datapackage_pipelines_mojp/clearmash/common.py
@@ -1,4 +1,4 @@
-import logging
+import logging, datetime
 
 
 def doc_show_filter(parsed_doc):
@@ -8,7 +8,7 @@ def doc_show_filter(parsed_doc):
     if bool(working_status == 'Completed' and rights == 'Full' and display_status not in ['Internal Use']):
         return True
     else:
-        warn_once("items are skipped due to show filter")
+        # warn_once("items are skipped due to show filter")
         return False
 
 
@@ -18,3 +18,36 @@ def warn_once(msg):
     if msg not in msg_cache:
         msg_cache.append(msg)
         logging.warning(msg)
+
+
+def check_download_ttl(existing_ids, item_id):
+    last_downloaded, hours_to_next_download, last_synced = existing_ids[int(item_id)]
+    now = datetime.datetime.now()
+    next_download = last_downloaded + datetime.timedelta(hours=hours_to_next_download)
+    seconds_to_next_download = (next_download - now).total_seconds()
+    if seconds_to_next_download < 0:
+        # should download the item
+        return True
+    else:
+        # don't download
+        return False
+
+
+def update_download_ttl(existing_ids, item_id):
+    last_synced, hours_to_next_download = None, None
+    if item_id:
+        item_id = int(item_id)
+        hours_to_next_download = 5
+        if item_id in existing_ids:
+            item_row = existing_ids[item_id]
+            if item_row is None:
+                # this signifies a row which was processed in current pipeline run and should be forcibly skipped
+                hours_to_next_download = None
+            else:
+                last_downloaded, hours_to_next_download, last_synced = existing_ids[item_id]
+                hours_to_next_download = hours_to_next_download * 2
+                if hours_to_next_download > 24 * 14:
+                    hours_to_next_download = 24 * 14
+        if hours_to_next_download is not None and hours_to_next_download < 5:
+            hours_to_next_download = 5
+    return last_synced, hours_to_next_download

--- a/datapackage_pipelines_mojp/clearmash/constants.py
+++ b/datapackage_pipelines_mojp/clearmash/constants.py
@@ -49,3 +49,19 @@ CONTENT_FOLDERS = {
 }
 
 DOWNLOAD_PROCESSOR_BUFFER_LENGTH = 10
+
+
+TEMPLATE_ID_COLLECTION_MAP = {
+    "_c6_beit_hatfutsot_bh_photos": common_constants.COLLECTION_PHOTOUNITS,
+    "_c6_beit_hatfutsot_bh_personality": common_constants.COLLECTION_PERSONALITIES,
+    "_c6_beit_hatfutsot_bh_place": common_constants.COLLECTION_PLACES,
+    "_c6_beit_hatfutsot_bh_family_name": common_constants.COLLECTION_FAMILY_NAMES,
+    "_c6_beit_hatfutsot_bh_exhibition": "unknown",
+    "_c6_beit_hatfutsot_bh_recieve_unit": "unknown",
+    "_c6_beit_hatfutsot_bh_source_tid": "unknown",
+    "_c6_beit_hatfutsot_bh_films": common_constants.COLLECTION_MOVIES,
+    "_c6_beit_hatfutsot_bh_familytree": "unknown",
+    "_c6_beit_hatfutsot_bh_family": "unknown",
+    "_c6_beit_hatfutsot_bh_musictext": "unknown",
+    "_c6_beit_hatfutsot_bh_music": "unknown",
+}

--- a/datapackage_pipelines_mojp/clearmash/processors/download.py
+++ b/datapackage_pipelines_mojp/clearmash/processors/download.py
@@ -49,6 +49,7 @@ class Processor(BaseProcessor):
                 logging.info("using OVERRIDE_CLEARMASH_ITEM_IDS env var: {}".format(self._override_item_ids))
 
     def _process(self, *args, **kwargs):
+        self._existing_ids = {}
         self._db_table = self._parameters.get("table")
         if self._db_table:
             self._db_table = self.db_meta.tables.get(self._db_table)

--- a/datapackage_pipelines_mojp/common/processors/delete.py
+++ b/datapackage_pipelines_mojp/common/processors/delete.py
@@ -3,6 +3,7 @@ from datapackage_pipelines_mojp.common.utils import get_elasticsearch
 from datapackage_pipelines_mojp.common import constants
 from elasticsearch import NotFoundError
 import logging
+import elasticsearch.helpers
 
 
 
@@ -13,29 +14,34 @@ class Processor(BaseProcessor):
     def _filter_resource(self, resource_descriptor, resource_data):
         self._es, self._idx = get_elasticsearch(self._settings)
         self._stats[self.STATS_DELETED] = 0
+        self._all_es_ids = self._get_all_es_ids()
         yield from super(Processor, self)._filter_resource(resource_descriptor, resource_data)
 
+    def _get_all_es_ids(self):
+        # TODO: optimize, this is really inefficient (but, done only once per pipeline run)
+        return [doc["_id"] for doc in elasticsearch.helpers.scan(self._es, index=self._idx,
+                                                                 doc_type=constants.PIPELINES_ES_DOC_TYPE,
+                                                                 scroll=u"3h")]
+
+
     def _delete(self, id):
-        try:
+        if id in self._all_es_ids:
             self._es.delete(index=self._idx, doc_type=constants.PIPELINES_ES_DOC_TYPE, id=id)
             self._stats[self.STATS_DELETED] += 1
-        except NotFoundError:
+        else:
             self._stats[self.STATS_DELETED] += 1
 
     def _filter_row(self, row):
         id = row[self._parameters["id-field"]]
         source = self._parameters["source"]
         es_id = "{}_{}".format(id, source)
-        logging.info(es_id)
         if self._parameters.get("delete-all-input"):
             delete = True
         else:
             delete = not row["display_allowed"]
         if delete:
             self._delete(es_id)
-            return None
-        else:
-            return row
+        return row
 
 
 if __name__ == '__main__':

--- a/datapackage_pipelines_mojp/common/processors/load_sql_resource.py
+++ b/datapackage_pipelines_mojp/common/processors/load_sql_resource.py
@@ -6,6 +6,8 @@ from sqlalchemy import *
 
 class LoadSqlResource(BaseProcessor):
 
+    STATS_NUM_ROWS = "number of loaded rows from DB"
+
     def _process(self, *args, **kwargs):
         self._db_table = self.db_meta.tables.get(self._parameters["load-table"])
         return super(LoadSqlResource, self)._process(*args, **kwargs)
@@ -52,7 +54,9 @@ class LoadSqlResource(BaseProcessor):
                 if i > 0 and i % 500 == 0:
                     logging.info("loaded {} / {}".format(i, num_total))
             logging.info("loaded {} / {}".format(num_rows, num_total))
-            self._stats["load_sql_resource_num_rows_yielded"] = num_rows
+            self._stats[self.STATS_NUM_ROWS] = num_rows
+        else:
+            self._stats[self.STATS_NUM_ROWS] = 0
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* fixes #72 - items should be assigned collection according to template_id 
  * now we assigne collection not by the folder items came from, but instead using the clearmash template_id
  * template_id is consistent with out collections
* also fix a problem with delete processor - which delete items that were allowed to display
* fix for download processes handling of ttls