### PR TITLE
clearmash: timeouts and rery handling, more details for folders and entity ids (to help research family trees)

### DIFF
--- a/clearmash/pipeline-spec.yaml
+++ b/clearmash/pipeline-spec.yaml
@@ -1,5 +1,5 @@
 entity-ids:
-  description: "downloads list of entity ids from clearmash folders (collections) and updates db table clearmash-entity-ids"
+  description: "downloads list of entity ids from clearmash folders (collections) and updates relevant db tables"
   schedule:
     # daily at 00:00
     crontab: "0 0 * * *"
@@ -7,10 +7,14 @@ entity-ids:
     - run: ..datapackage_pipelines_mojp.clearmash.processors.add_entity_ids
       parameters:
         add-resource: entity-ids
+        # this processor dumps data about folders to this DB table
+        folder-ids-table: clearmash-folder-ids
+    # this updates the entity ids DB table
     - run: ..datapackage_pipelines_mojp.common.processors.dump_to_sql
       parameters:
         resource: entity-ids
         table: clearmash-entity-ids
+        commit-every: 10000
 
 download-entities:
   description: "downloads entities - both new and updated, according to last downloaded and hours_to_next_download, updates db table clearmash-entities"

--- a/datapackage_pipelines_mojp/common/db.py
+++ b/datapackage_pipelines_mojp/common/db.py
@@ -26,6 +26,6 @@ def get_connection(session=None, engine=None, connection_string=None):
 
 
 def get_reflect_metadata(session):
-    meta = MetaData(bind=session.connection())
+    meta = MetaData(bind=session.get_bind())
     meta.reflect()
     return meta

--- a/datapackage_pipelines_mojp/common/processors/dump_to_sql.py
+++ b/datapackage_pipelines_mojp/common/processors/dump_to_sql.py
@@ -2,57 +2,93 @@ from datapackage_pipelines_mojp.common.processors.base_processors import BasePro
 from jsontableschema_sql.mappers import descriptor_to_columns_and_constraints
 from sqlalchemy import Table
 import logging
+from sqlalchemy.ext.automap import automap_base
 
 
 class Processor(BaseProcessor):
 
-    @property
-    def _db_table(self):
-        return self.db_meta.tables.get(self._tablename)
-
     def _create_table(self):
-        if self._db_table is None:
-            columns, constraints, indexes = descriptor_to_columns_and_constraints("", self._tablename, self._schema, (), None)
-            Table(self._tablename, self.db_meta, *(columns + constraints + indexes)).create()
-            self._stats["was table created?"] = "yes"
-            logging.info("created table {}".format(self._tablename))
+        columns, constraints, indexes = descriptor_to_columns_and_constraints("", self._tablename, self._schema, (), None)
+        table = Table(self._tablename, self.db_meta, *(columns + constraints + indexes))
+        table.create()
+        self._stats["was table created?"] = "yes"
+        logging.info("{}: created table".format(self._tablename))
+        return table
+
+    def _get_mapper(self):
+        Base = automap_base(metadata=self.db_meta)
+        Base.prepare()
+        return getattr(Base.classes, self._tablename)
+
+    def db_commit(self):
+        if len(self._rows_buffer) > 0:
+            table = self.db_meta.tables.get(self._tablename)
+            if table is None:
+                table = self._create_table()
+            mapper = self._get_mapper()
+            update_rows = []
+            insert_rows = []
+            for row in self._rows_buffer:
+                filter_args = (getattr(table.c, field)==row[field] for field in self._update_keys)
+                if self.db_session.query(table).filter(*filter_args).count() > 0:
+                    update_rows.append(row)
+                else:
+                    insert_rows.append(row)
+            if len(insert_rows) > 0:
+                self.db_session.bulk_insert_mappings(mapper, insert_rows)
+                self._stats["number of inserted rows"] += len(insert_rows)
+            if len(update_rows) > 0:
+                self.db_session.bulk_update_mappings(mapper, update_rows)
+                self._stats["number of updated rows"] += len(update_rows)
+            super(Processor, self).db_commit()
+            logging.info("{}: commit ({} updated, {} inserted)".format(self._tablename,
+                                                                       self._stats["number of updated rows"],
+                                                                       self._stats["number of inserted rows"]))
+            self._rows_buffer = []
 
     def _filter_row(self, row):
         self._row_num += 1
-        if self._row_num%self._commit_buffer_length == 0:
-            logging.info("commit ({} updated, {} inserted)".format(self._stats["number of updated rows"], self._stats["number of inserted rows"]))
+        if self._commit_buffer_length > 1:
+            if self._row_num%self._commit_buffer_length == 0:
+                self.db_commit()
+        self._rows_buffer.append(row)
+        if self._commit_buffer_length < 2:
             self.db_commit()
-        filter_args = (getattr(self._db_table.c, field)==row[field] for field in self._update_keys)
-        table = self._db_table
-        if self.db_session.query(table).filter(*filter_args).count() > 0:
-            # update
-            values = {field: row[field] for field in row if field not in self._update_keys}
-            stmt = table.update()
-            for arg in filter_args:
-                stmt.where(arg)
-            stmt.values(**values).execute()
-            self._stats["number of updated rows"] += 1
-        else:
-            # insert
-            table.insert().values(**row).execute()
-            self._stats["number of inserted rows"] += 1
         return row
 
-    def _filter_resource(self, *args):
+    def _filter_resource_init(self, schema):
         self._stats["number of updated rows"] = 0
         self._stats["number of inserted rows"] = 0
         self._stats["was table created?"] = "no"
         self._tablename = self._parameters["table"]
-        self._schema = self._get_resource_descriptor()["schema"]
+        self._schema = schema
         self._update_keys = self._schema["primaryKey"]
-        self._create_table()
         self._commit_buffer_length = int(self._parameters.get("commit-every", "100"))
         self._stats["committed every X rows"] = self._commit_buffer_length
         self._row_num = 0
-        logging.info("committing every {} rows".format(self._stats["committed every X rows"]))
+        self._rows_buffer = []
+        if self._commit_buffer_length > 1:
+            logging.info("{}: initialized, committing every {} rows".format(self._tablename,
+                                                                            self._stats["committed every X rows"]))
+        else:
+            logging.info("{}: initialized".format(self._tablename))
+
+    def _filter_resource(self, *args):
+        self._filter_resource_init(self._get_resource_descriptor()["schema"])
         yield from super(Processor, self)._filter_resource(*args)
         self.db_commit()
 
+    @classmethod
+    def initialize(cls, table_name, schema, settings=None):
+        processor = cls({"resource": "_", "table": table_name, "commit-every": 0},
+                        {"name": "_", "resources": [{"name": "_", "schema": schema}]},
+                        [], settings)
+        processor._filter_resource_init(schema)
+        return processor
+
+    def commit_rows(self, rows):
+        self._rows_buffer = rows
+        self.db_commit()
 
 if __name__ == '__main__':
     Processor.main()

--- a/tests/clearmash/pipeline-spec.yaml
+++ b/tests/clearmash/pipeline-spec.yaml
@@ -6,6 +6,8 @@ entity-ids:
     - run: test_add_entity_ids
       parameters:
         add-resource: entity-ids
+        # this processor dumps data about folders to this DB table
+        folder-ids-table: clearmash-folder-ids
     - run: ...datapackage_pipelines_mojp.common.processors.dump_to_sql
       parameters:
         resource: entity-ids


### PR DESCRIPTION
* added clearmash-folder-ids table - with details of folders (to help debug how family trees are stored)
* added timeouts and retry handling for clearmash api requests - 
  * set proper connect and read timeouts
  * does by default 5 retries for each request, increasing sleep time between each request
* added more details to clearmash-entity-ids table (to help with debugging family trees)

### deployment
* need to drop clearmash-entity-ids table (the schema changed, and it had some wrong data)
